### PR TITLE
- Javadoc

### DIFF
--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Commit.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Commit.java
@@ -18,10 +18,22 @@
 package org.apache.jackrabbit.oak.plugins.segment.scheduler;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
+import org.apache.jackrabbit.oak.plugins.segment.SegmentStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
+/**
+ * A {@code Commit} instance represents a set of related changes that atomically take a
+ * {@link SegmentStore} instance from its current persisted state to the next persisted state.
+ */
 public interface Commit {
 
-    NodeState apply(NodeState base) throws CommitFailedException;
+    /**
+     * Apply the changes represented by this commit to the passed {@code store}.
+     *
+     * @param store  the {@code SegmentStore} instance to apply this commit to
+     * @return       the resulting state from applying this commit
+     * @throws CommitFailedException
+     */
+    NodeState apply(SegmentStore store) throws CommitFailedException;
 
 }

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Commit.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Commit.java
@@ -18,22 +18,23 @@
 package org.apache.jackrabbit.oak.plugins.segment.scheduler;
 
 import org.apache.jackrabbit.oak.api.CommitFailedException;
-import org.apache.jackrabbit.oak.plugins.segment.SegmentStore;
 import org.apache.jackrabbit.oak.spi.state.NodeState;
 
 /**
- * A {@code Commit} instance represents a set of related changes that atomically take a
- * {@link SegmentStore} instance from its current persisted state to the next persisted state.
+ * A {@code Commit} instance represents a set of related changes, which when applied to
+ * a base node state result in a new node state.
  */
 public interface Commit {
 
     /**
-     * Apply the changes represented by this commit to the passed {@code store}.
+     * Apply the changes represented by this commit to the passed {@code base}
+     * node state.
      *
-     * @param store  the {@code SegmentStore} instance to apply this commit to
-     * @return       the resulting state from applying this commit
-     * @throws CommitFailedException
+     * @param base   the base node state to apply this commit to
+     * @return       the resulting state from applying this commit to {@code base}.
+     * @throws CommitFailedException  if the commit cannot be applied to {@code base}.
+     *                                (e.g. because of a conflict.)
      */
-    NodeState apply(SegmentStore store) throws CommitFailedException;
+    NodeState apply(NodeState base) throws CommitFailedException;
 
 }

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/CommitBacklog.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/CommitBacklog.java
@@ -17,8 +17,22 @@
 
 package org.apache.jackrabbit.oak.plugins.segment.scheduler;
 
-public interface CommitStream {
+import org.apache.jackrabbit.oak.plugins.segment.SegmentStore;
 
+/**
+ * A back log of {@link Commit commits} yet to be applied to a
+ * {@link SegmentStore segment store}.
+ */
+public interface CommitBacklog {
+
+    /**
+     * Returns the next commit blocking until one becomes available if
+     * there is currently none. Returns {@code null} if the underlying
+     * store does not accept any further commits (e.g. because it is
+     * shutting down or in an error state).
+     *
+     * @return  the next commit or {@code null}.
+     */
     Commit next();
 
 }

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/ScheduledCommits.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/ScheduledCommits.java
@@ -23,7 +23,7 @@ import org.apache.jackrabbit.oak.plugins.segment.SegmentStore;
  * A back log of {@link Commit commits} yet to be applied to a
  * {@link SegmentStore segment store}.
  */
-public interface CommitBacklog {
+public interface ScheduledCommits {
 
     /**
      * Returns the next commit blocking until one becomes available if

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Scheduler.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Scheduler.java
@@ -17,12 +17,38 @@
 
 package org.apache.jackrabbit.oak.plugins.segment.scheduler;
 
+import org.apache.jackrabbit.oak.api.CommitFailedException;
 import org.apache.jackrabbit.oak.spi.commit.CommitHook;
 import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
 import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 
+/**
+ * A {@code Scheduler} instance transforms changes to the content tree
+ * into a {@link CommitBacklog backlog} of {@link Commit commits}.
+ * <p>
+ * An implementation is free to employ any scheduling strategy as long
+ * as it guarantees all changes are applied atomically without changing
+ * the semantics of the changes recorded in the {@code NodeBuilder} nor
+ * the semantics of the {@code CommitHook} passed to the
+ * {@link #schedule(NodeBuilder, CommitHook, CommitInfo, SchedulerOptions) schedule}
+ * method.
+ */
 public interface Scheduler<S extends SchedulerOptions> {
 
-    void schedule(NodeBuilder builder, CommitHook hook, CommitInfo info, S options);
+    /**
+     * Schedule {@code changes} for committing. This method blocks until the
+     * {@code changes} have been processed and persisted. That is, until a call
+     * to {@code SegmentStore.getHead} would return a node state reflecting those
+     * changes.
+     *
+     * @param changes    changes to commit
+     * @param hook       commit hook to run as part of the commit process
+     * @param info       commit info pertaining to this commit
+     * @param schedulingOptions       implementation specific scheduling options
+     * @throws CommitFailedException  if the commit failed and none of the changes
+     *                                have been applied.
+     */
+    void schedule(NodeBuilder changes, CommitHook hook, CommitInfo info, S schedulingOptions)
+    throws CommitFailedException;
 
 }

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Scheduler.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/Scheduler.java
@@ -24,7 +24,7 @@ import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
 
 /**
  * A {@code Scheduler} instance transforms changes to the content tree
- * into a {@link CommitBacklog backlog} of {@link Commit commits}.
+ * into a {@link ScheduledCommits backlog} of {@link Commit commits}.
  * <p>
  * An implementation is free to employ any scheduling strategy as long
  * as it guarantees all changes are applied atomically without changing

--- a/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/SchedulerOptions.java
+++ b/oak-segment/src/main/java/org/apache/jackrabbit/oak/plugins/segment/scheduler/SchedulerOptions.java
@@ -17,6 +17,16 @@
 
 package org.apache.jackrabbit.oak.plugins.segment.scheduler;
 
+import org.apache.jackrabbit.oak.spi.commit.CommitHook;
+import org.apache.jackrabbit.oak.spi.commit.CommitInfo;
+import org.apache.jackrabbit.oak.spi.state.NodeBuilder;
+
+/**
+ * Scheduling options for parametrising individual
+ * {@link Scheduler#schedule(NodeBuilder, CommitHook, CommitInfo, SchedulerOptions) commits}.
+ * (E.g. expedite, prioritise, defer, collapse, coalesce, parallelise, etc).
+ *
+ */
 public interface SchedulerOptions {
 
 }


### PR DESCRIPTION
- Commit.apply() takes SegmentStore instead of NodeState as its argument
- Rename CommitStream to CommitBacklog
- Scheduler.schedule() can throw CommitFailedException